### PR TITLE
Fix autoload errors

### DIFF
--- a/lib/puppet/feature/aws_sdk.rb
+++ b/lib/puppet/feature/aws_sdk.rb
@@ -1,0 +1,1 @@
+Puppet.features.add(:aws_sdk, :libs => ["aws-sdk"])

--- a/lib/puppet/provider/ec2_tag/aws.rb
+++ b/lib/puppet/provider/ec2_tag/aws.rb
@@ -1,8 +1,9 @@
-require 'aws-sdk'
 require 'yaml'
 
 Puppet::Type.type(:ec2_tag).provide :aws do
   desc "Provider to set EC2 tags on AWS"
+
+  confine :feature => :aws_sdk
 
   def create
     ec2.create_tags({

--- a/lib/puppet/type/ec2_tag.rb
+++ b/lib/puppet/type/ec2_tag.rb
@@ -13,4 +13,9 @@ Puppet::Type.newtype(:ec2_tag) do
     desc "The value the tag should have"
   end
 
+  # Ensure that the aws-sdk gem is installed before we do anything
+  autorequire(:package) do
+    'aws-sdk'
+  end
+
 end


### PR DESCRIPTION
This change adds aws-sdk as a feature, so Puppet will defer applying the ec2_tag resource until the feature is available. I've also added an autorequire on the aws-sdk package, to ensure that it is installed before the resource is used.